### PR TITLE
Fix bug where luxury industry buildings cannot be built for a resource if that resource is on the city center

### DIFF
--- a/third_party/beyond-the-sword-sdk/CvGameCoreDLL/CvCity.cpp
+++ b/third_party/beyond-the-sword-sdk/CvGameCoreDLL/CvCity.cpp
@@ -77,7 +77,9 @@ namespace
 				continue;
 			}
 
-			if (bRequireImproved && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
+			const bool bIsCityCenterPlot = (pLoopPlot == kCity.plot());
+
+			if (bRequireImproved && !bIsCityCenterPlot && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
 			{
 				continue;
 			}


### PR DESCRIPTION
Automated Symphony handoff for #43.

## Summary
- Issue: #43
- Branch: `symphony/43-fix-bug-where-luxury-industry-buildings-cannot-be-built-for-a-resource-if-that-resource-is-on-the-city-center`

## Changed Files
- `third_party/beyond-the-sword-sdk/CvGameCoreDLL/CvCity.cpp`

## Validation
`powershell -NoProfile -ExecutionPolicy Bypass -File C:\sw\gh-43\tools\test_gate.ps1 -RepoRoot C:\sw\gh-43 -CheckDll` passed.

## Manual Testing
- Gameplay-impacting DLL/XML changes were detected.
- Run the manual smoke test flow in `docs/MANUAL_SMOKE_TESTS.md` before merge.

Closes #43