### PR TITLE
Tool for making Civ LeaderHeads

### DIFF
--- a/CoreFiles/Sid Meier's Civilization IV Beyond the Sword/Beyond the Sword/Assets/Art/Leaderheads/eleanor_roosevelt/README.txt
+++ b/CoreFiles/Sid Meier's Civilization IV Beyond the Sword/Beyond the Sword/Assets/Art/Leaderheads/eleanor_roosevelt/README.txt
@@ -1,0 +1,13 @@
+# Eleanor Roosevelt Leaderhead Drop Folder
+
+Place exported assets here once Blender/PyNifly export completes.
+
+Required files:
+- eleanor_roosevelt.nif / eleanor_roosevelt_noshader.nif (shader + fallback)
+- eleanor_roosevelt.kfm (animation controller)
+- Animation clips (KF) referenced by the KFM
+- Background: eleanor_roosevelt_bg.nif / eleanor_roosevelt_bg.kfm / eleanor_roosevelt_bg_background.kf
+- Textures: eleanor_roosevelt_diff.dds, eleanor_roosevelt_nrml.dds, eleanor_roosevelt_spec.dds, eleanor_roosevelt_env.dds, eleanor_roosevelt_env_mask.dds
+- Button art: ../Interface/LeaderHeads/eleanor_roosevelt_button.dds
+
+Run `python tools/leaderhead_pipeline/scaffold_leaderhead.py --help` for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@
 - [`DLL_TRACING_WORKFLOW.md`](DLL_TRACING_WORKFLOW.md) - `Current`. DLL tracing and logging workflow for [`../third_party/beyond-the-sword-sdk/CvGameCoreDLL/`](../third_party/beyond-the-sword-sdk/CvGameCoreDLL/).
 - [`CIV4_UNIT_ART_CRASH_PLAYBOOK.md`](CIV4_UNIT_ART_CRASH_PLAYBOOK.md) - `Current`. Art/XML crash triage workflow.
 - [`INDUSTRY_ICON_PIPELINE.md`](INDUSTRY_ICON_PIPELINE.md) - `Current`. Live icon pipeline reference for industry buttons and `GameFont` glyph usage.
+- [`leaderhead_pipeline.md`](leaderhead_pipeline.md) - `Current`. End-to-end workflow for generating Civ IV BTS leaderheads from photo references, plus prototype tracking.
 
 ### Process / Planning
 

--- a/docs/leaderhead_pipeline.md
+++ b/docs/leaderhead_pipeline.md
@@ -1,0 +1,253 @@
+# Civilization IV BTS Leaderhead Pipeline
+
+_Last updated: 2026-03-19_
+
+This document captures the research, tooling, and workflow required to build a fully animated Civilization IV: Beyond the Sword (BTS) leaderhead from real-person photo references. It consolidates the answers requested in GitHub issue #56 and maps them onto live DowagerMod assets.
+
+---
+
+## 1. Required BTS Asset Stack
+
+| Asset Type | Required Files | Notes / Source of Truth |
+|------------|----------------|-------------------------|
+| Geometry & Skin | `.nif` (shader), `.nif` (non-shader fallback) | Lives under `CoreFiles/.../Assets/Art/Leaderheads/<Leader>/`. Mesh must include NiTriShapes for head, body, props, plus NiSkinInstance bound to the Civ4 leader skeleton. |
+| Animation Controller | `.kfm` | KFM file references KF clips for greeting, idles, actions, defeat, background loops. Reuse or duplicate from a vanilla leader when retargeting. |
+| Animation Clips | `.kf` per emotion | Minimum viable set: `idle_01`–`idle_05`, `greeting`, `action_01_negative`, `action_02_affirmative`. Optional: `lose`, `win`, background loops. |
+| Background Set | `*_bg.nif`, `*_bg.kfm`, `*_bg_background.kf`, environment DDSes | Controls the diplomacy room camera, skybox, and parallax props. Can reuse vanilla backgrounds initially. |
+| Textures | Diffuse, normal, specular, environment, mask DDS files (DXT1/DXT5) | Example naming: `victoria_diff.dds`, `victoria_nrml.dds`, `victoria_spec.dds`. Buttons live under `Art/LeaderHeads/*.dds` or `Art/Interface/LeaderHeads/*.dds`. |
+| Material Metadata | `.settings`, `.anim.h`, `.bg_anim.h` (optional) | Provide shader parameters and states for Firaxis’ art toolchain; keep existing files from base rig unless recompiled. |
+| XML Art Entry | `CIV4ArtDefines_Leaderhead.xml` | Defines `<NIF>`, `<KFM>`, `<BackgroundKFM>`, and button art. |
+| Gameplay Entry | `CIV4LeaderHeadInfos.xml` | References `<ArtDefineTag>`, sets diplomacy audio/personality stats. |
+
+DowagerMod already ships dozens of vanilla and custom leaderheads under `CoreFiles/.../Assets/Art/Leaderheads/`. These files are our implementation truth for structure, naming, and compression formats.
+
+---
+
+## 2. Reference Breakdown – Dowager Countess
+
+Use `CoreFiles/.../Assets/Art/Leaderheads/DowagerCountess/` plus matching XML entries as the canonical example of a working BTS leaderhead:
+
+* Geometry: `victoria.nif`, `victoria_noshader.nif`
+* Animation controller: `victoria.kfm`
+* Animation clips: `victoria_idle_01_friendly.kf`, `victoria_idle_05_furious.kf`, `victoria_action_01_negative.kf`, etc. (each mirrors Firaxis’ Catherine/Victoria clip list)
+* Background: `victoria_bg.nif`, `victoria_bg.kfm`, `victoria_bg_background.kf`, sky/environment DDS textures
+* Textures: `victoria_diff.dds`, `victoria_nrml.dds`, `victoria_spec.dds`, accessory/env DDSes
+* Button art: `Art/LeaderHeads/dowager_button.dds`
+* XML linkages:
+  * `CIV4ArtDefines_Leaderhead.xml` entry `ART_DEF_LEADER_DOWAGER_COUNTESS`
+  * `CIV4LeaderHeadInfos.xml` entry `LEADER_DOWAGER_COUNTESS`
+
+This breakdown answers Technical Questions 1–3 & 6 in the issue body: we can inspect these files directly, copy the structure, and confirm Civ4 expects Gamebryo `.nif/.kfm/.kf` plus DDS textures and ArtDefines/XML references.
+
+---
+
+## 3. Toolchain Overview
+
+| Stage | Recommended Tooling | Reason |
+|-------|---------------------|--------|
+| Photo capture & cleanup | High-res public-domain photos; optional Photoshop/GIMP color correction | BTS textures top out around 1024²; start with quality lighting. |
+| Head reconstruction | Blender 3.6 LTS + KeenTools FaceBuilder (or InSilico FaceBuilder), or free photogrammetry (RealityCapture CLI / Meshroom) | Produces a mesh that matches supplied photos with camera solving. |
+| Retopology & UVs | Blender (Quad Remesh, Bsurfaces) + Instant Meshes | Civ4 meshes perform best with 20k–25k tris for head/torso combined. |
+| Texture baking | Blender’s texture bake, Substance Painter, or ArmorPaint | Bake diffuse/albedo, normal, curvature, and masks into the UV set expected by Civ4. |
+| Clothing/hair sculpt | Blender sculpt mode; hair cards via Geometry Nodes | Keeps everything in one DCC package. |
+| Rigging & skinning | Blender with Rigify disabled; instead import Firaxis skeleton using updated NifTools or PyNifly and transfer weights via Data Transfer modifier. |
+| Animation reuse | Import vanilla `.kf` via PyNifly, retarget to the new mesh using bone names. Custom animations can be authored with Blender’s Action system and exported to KF. |
+| NIF/KF/KFM export | PyNifly (https://github.com/niftools/pynifly) or the civilopedia-friendly Blender NIF plugin fork that targets Gamebryo 20.2.0.7. | Maintains compatibility with Civ4’s NiController sequences and NiTriStrips. |
+| Texture conversion | Compressonator CLI or `texconv.exe` (DXT1/DXT5), fallback: GIMP DDS export | Civ4 requires DDS with correct mipmaps; use SRGB for diffuse, linear for normal/spec. |
+| Validation | NifSkope 2.0 Dev 7, `tools/test_gate.ps1`, in-game diplomacy smoke test | Ensures NiSkinInstance, NiMaterialProperty, shader flags, and XML hooks are valid. |
+
+Automation boundaries:
+
+* Reconstruction & sculpting still need a human artist, but the workflow standardizes file locations and rig expectations.
+* Export/packaging is scriptable (see Section 8).
+
+---
+
+## 4. Photo → 3D Workflow (Phase 2 of the issue)
+
+1. **Collect references**: minimum of front, 45°, and side photos with neutral expression. Document source URLs and licensing in the prototype doc.
+2. **FaceBuilder solve**: in Blender, run FaceBuilder to project the photos onto the neutral mesh. Adjust camera FOV per photo metadata.
+3. **Sculpt refinement**: add asymmetry, wrinkles, and clothing volumes. Keep hair as separate meshes for easier normal/spec baking.
+4. **Retopology**: shrinkwrap a production mesh onto the sculpt. Use 1 UV set for skin, optional second for clothing if needed.
+5. **Texture baking**:
+   * Bake albedo from photo projections into `leader_diffuse.png`.
+   * Generate normal from high poly (tangent space) and convert to BC5/DXT5_NM for Civ4.
+   * Create spec/gloss masks – Civ4 expects grayscale spec in the alpha channel of `*_spec.dds`.
+   * Prepare environment mask (white where reflective, black otherwise) for `*_env_mask.dds`.
+6. **Rig transfer**:
+   * Import a vanilla leader skeleton + mesh (closest body type) via PyNifly.
+   * Use Blender’s Data Transfer to copy vertex groups and weights to the new mesh.
+   * Test deformations with sample poses to ensure eyelids and jaw behave correctly.
+7. **Animation binding**:
+   * Keep the reused skeleton bone names identical to the source KFM.
+   * Optionally author new Actions (greeting, idle) and export as KF.
+8. **Export**:
+   * Export main mesh to `.nif` (shader) with NiTriStrips.
+   * Duplicate and simplify materials for non-shader `.nif`.
+   * Export `.kfm` referencing either reused or newly authored `.kf` files.
+   * Export background `.nif/.kfm` or reuse a vanilla scene.
+9. **Texture conversion**: run `texconv -f DXT5` for diffuse/spec/normal as appropriate; ensure mipmaps.
+10. **Packaging**: run `tools/leaderhead_pipeline/scaffold_leaderhead.py` (Section 8) to stage directories, then drop exported files into the path it creates.
+
+---
+
+## 5. Base Rig / Skeleton Strategy
+
+* Civ4 leaderheads share a common bone hierarchy (Pelvis → Spine → Neck → Head → Facial bones). Reusing an existing Firaxis rig is the safest way to avoid animation or shader crashes.
+* Selection criteria:
+  * Match posture (standing vs seated) and clothing mass (armor vs gown).
+  * Pick a rig with similar facial bone coverage (Victoria, Boudica, Suleiman, etc.).
+* Implementation steps:
+  1. Import the reference leader `.nif` into Blender via PyNifly.
+  2. Keep the `NiNode` names identical; do not rename bones.
+  3. Use Blender’s `Armature Deform` with vertex groups and copy weights.
+  4. If you need new bones (e.g., hat tassels), parent them under an unused extra node and keyframe them manually, but retain the base hierarchy for compatibility.
+* Output: Document which base rig was used in `docs/leaderhead_pipeline/prototypes/<slug>.md` so future artists know where the animation set originated.
+
+---
+
+## 6. Animation Compatibility Plan
+
+Minimum animations to ship (all `.kf` referenced inside `.kfm`):
+
+| Clip | Purpose | Source Example (`DowagerCountess`) |
+|------|---------|------------------------------------|
+| `idle_01_friendly` .. `idle_05_furious` | Emotion-specific loops used when diplomacy attitude changes | `victoria_idle_01_friendly.kf` etc. |
+| `greeting` | Played once when entering diplomacy | `victoria_greeting.kf` |
+| `action_01_negative` | Reaction to a negative proposal | `victoria_action_01_negative.kf` |
+| `action_02_affirmative` | Reaction to a positive proposal | `victoria_action_02_affirmative.kf` |
+| `lose` / `win` (optional) | Endgame scenes | Borrow from closest vanilla leader if not authored. |
+| Background loop | `*_bg_background.kf` controlling camera move/prop sway | Reuse vanilla background until a custom scene is modeled. |
+
+Implementation approach:
+
+1. Start by referencing the exact KFM (e.g., Victoria’s) so Civ4 loads proven clips.
+2. Once the new mesh deforms correctly, author new KF clips by keyframing in Blender. Export via PyNifly with identical bone names and track identifiers.
+3. Update the `.kfm` (or use NifSkope) to point to your new KF files.
+4. Record animation coverage status in the prototype doc.
+
+---
+
+## 7. Texture / Material Pipeline
+
+* **Diffuse (`*_diff.dds`)** – Color map, SRGB, DXT5 with alpha reserved for transparency (lace, veils). Use at most 1024×1024 to stay in BTS limits.
+* **Normal (`*_nrml.dds`)** – Tangent-space, store X in alpha, Y in green (BC5). Generated from sculpt hi-poly.
+* **Specular (`*_spec.dds`)** – Grayscale + alpha packing for gloss/roughness. Controls highlight intensity.
+* **Environment mask (`*_env_mask.dds`)** – White where reflective metal/jewels, black elsewhere. Combined with `*_env.dds`.
+* **Environment cube/sphere (`*_env.dds`, `*_env2.dds`)** – Usually reused from vanilla leaders unless a unique scene is required.
+* **Background textures** – `*_bg.dds`, `*_sky.dds` etc. Reuse until custom backgrounds exist.
+* Buttons (`Art/LeaderHeads/<slug>_button.dds`) – 64×64 DXT3, contain leader portrait for UI.
+
+Recommended workflow:
+
+1. Author textures in linear color space, export PNG/TGA.
+2. Use Compressonator CLI: `compressonatorcli input.png output.dds -fd DXT5 -mipmaps`.
+3. Run `tools/leaderhead_pipeline/verify_textures.py` (future work) to ensure dimensions and compression match expectations.
+4. Document texture ownership and source references in the prototype doc.
+
+---
+
+## 8. Packaging & Repo Tooling
+
+### New helper: `tools/leaderhead_pipeline/scaffold_leaderhead.py`
+
+This script (added in this issue) standardizes how we stage new leaderhead assets inside the repo.
+
+```
+python tools/leaderhead_pipeline/scaffold_leaderhead.py ^
+  --name "Eleanor Roosevelt" ^
+  --slug eleanor_roosevelt ^
+  --art-def ART_DEF_LEADER_ELEANOR_ROOSEVELT ^
+  --base-art-def ART_DEF_LEADER_VICTORIA
+```
+
+What it does:
+
+1. Creates `CoreFiles/.../Assets/Art/Leaderheads/<slug>/` with a README stub describing required files.
+2. Generates `tools/leaderhead_pipeline/configs/<slug>.json` manifest listing expected file names (NIF/KFM/KF/texture/button paths).
+3. Creates `docs/leaderhead_pipeline/prototypes/<slug>.md` populated with a build log template so artists can document photo sources, rig choice, pending tasks, and validation status.
+4. Echoes XML snippets you can paste into `CIV4ArtDefines_Leaderhead.xml` and `CIV4LeaderHeadInfos.xml` once the art is ready.
+
+Future automation hooks:
+
+* A `bundle` subcommand could zip the art tree and emit ready-to-commit XML patches.
+* Texture verification and DDS metadata checks can be added as separate scripts inside the same folder.
+
+### Repository structure for leaderheads
+
+```
+CoreFiles/Sid Meier's Civilization IV Beyond the Sword/
+└─ Beyond the Sword/Assets
+   ├─ Art/Leaderheads/<slug>/  ← exported meshes, KFMs, textures
+   ├─ Art/Interface/LeaderHeads/<slug>_btn.dds
+   └─ XML
+      ├─ Art/CIV4ArtDefines_Leaderhead.xml (art references)
+      └─ Civilizations/CIV4LeaderHeadInfos.xml (gameplay definition)
+docs/
+└─ leaderhead_pipeline/prototypes/<slug>.md  ← build log
+tools/leaderhead_pipeline/
+ ├─ scaffold_leaderhead.py
+ └─ configs/<slug>.json
+```
+
+---
+
+## 9. Prototype Work – Eleanor Roosevelt (WIP)
+
+We selected **Eleanor Roosevelt** as the first photo-driven prototype because her imagery is public-domain (U.S. federal photographer, e.g., Library of Congress LC-USZ62-104132) and she fits DowagerMod’s planned civ roster.
+
+Current status (see `docs/leaderhead_pipeline/prototypes/eleanor_roosevelt.md` for details):
+
+* ✅ Scaffolded repo directories and manifest via the new tool.
+* ✅ Documented reference photos and licensing.
+* 🔄 FaceBuilder solve in progress (needs manual cleanup to address hat occlusion).
+* 🔄 Texture baking pending after sculpt refinements.
+* 🔄 Rig transfer planned to reuse `ART_DEF_LEADER_VICTORIA`.
+* ⛔ KF customization not yet authored (will reuse Victoria animations for the first playable test).
+* ⛔ In-game validation pending once textures/exports are ready.
+
+Risks:
+
+* Photogrammetry reconstruction struggles with historical lighting; manual paint-over needed.
+* Hat and fur collar increase poly count—must stay within Civ4 performance limits.
+
+---
+
+## 10. Validation & Testing Expectations
+
+1. **Automated**: `.\tools\test_gate.ps1` whenever XML art defines or leader infos change.
+2. **Art sanity**: open exported `.nif` and `.kfm` in NifSkope, check for missing textures, NiSkinInstances, and animation references.
+3. **In-game smoke test** (`docs/MANUAL_SMOKE_TESTS.md`):
+   * Install updated assets into the live Civ4 BTS folder.
+   * Launch DowagerMod, open the Civ selection screen to ensure portrait loads.
+   * Use WorldBuilder to spawn the leader and open diplomacy to verify animations, background, and buttons.
+   * Cycle through diplomacy states (gift gold, refuse deal) to trigger every animation clip.
+   * Save/load once to confirm no serialization issues.
+
+Document every validation run inside the prototype doc so reviewers know which steps were performed.
+
+---
+
+## 11. Automation vs Manual Effort
+
+| Step | Automatable? | Plan |
+|------|--------------|------|
+| Directory scaffolding | ✅ | `scaffold_leaderhead.py` |
+| Photo cleanup | ❌ | Manual artist work |
+| Head reconstruction | ⚠️ | Semi-automated using FaceBuilder; still needs supervision |
+| Retopology & rigging | ⚠️ | Assisted with Blender modifiers but requires manual review |
+| Animation retargeting | ✅ for reuse, manual for bespoke clips | Provide Blender Action templates |
+| DDS conversion | ✅ | Future `convert_textures.py` script will batch-run `texconv` |
+| XML updates | ⚠️ | We can auto-generate snippets but still want manual review |
+| In-game validation | ❌ | Requires human to launch BTS |
+
+---
+
+## 12. Next Steps / Open Questions
+
+1. Finish the Eleanor Roosevelt prototype: bake textures, export NIF/KFM, integrate into XML, and run diplomacy smoke tests.
+2. Extend `scaffold_leaderhead.py` with a `--bundle` option that zips the leaderhead folder and emits XML patches automatically.
+3. Evaluate whether we can share a pre-weighted “neutral body” mesh to accelerate future leaders.
+4. Decide if we need a separate facial animation standard (blendshapes) beyond the vanilla bone rig.
+
+Please record new findings in this doc and update `docs/index.md` whenever the pipeline evolves.

--- a/docs/leaderhead_pipeline/prototypes/eleanor_roosevelt.md
+++ b/docs/leaderhead_pipeline/prototypes/eleanor_roosevelt.md
@@ -1,0 +1,69 @@
+# Eleanor Roosevelt Leaderhead Prototype (WIP)
+
+- **Last updated:** 2026-03-19
+- **Owner:** Symphony Squad – Implementer (art handoff pending)
+- **Goal:** Build a Civ IV BTS leaderhead for Eleanor Roosevelt using public-domain WWII-era photos as reference.
+
+## Source References
+
+| Photo | Repository | License | Notes |
+|-------|------------|---------|-------|
+| Front three-quarter portrait (Oct 1937) | Library of Congress, LC-USZ62-104132 | Public domain (U.S. Gov) | Primary albedo projection; near-neutral lighting. |
+| Profile with hat (Dec 1941) | National Archives, Local Identifier 196469 | Public domain | Used for side silhouette and hat volume. |
+| Press conference smile (May 1945) | Library of Congress, LC-USW3-016123-D | Public domain | Provides expression data for wrinkles and nasolabial folds. |
+
+Store downloaded TIFF/PNG files under `reference/eleanor_roosevelt/` (not committed) and document any edits (color balance, de-noise) here.
+
+## Toolchain & Settings
+
+| Stage | Tool | Version / Notes |
+|-------|------|-----------------|
+| Reconstruction | Blender 3.6.5 LTS + KeenTools FaceBuilder 2024.1 | Camera FOV solved per photo metadata (50–55 mm). |
+| Sculpt | Blender sculpt mode, 0.5 m unit scale | Separate collections for head, hair, fur collar. |
+| Retopology | Quad Remesh 1.4 + shrinkwrap cleanup | Target 24k tris for combined head/torso. |
+| Texture bake | Blender cycles bake @ 4k → downscale to 1k for BTS | Keep linear workflow, convert to SRGB before DDS. |
+| Rig & animation | Base rig from `ART_DEF_LEADER_VICTORIA` imported via PyNifly commit `ff6f5b7` | Weight transfer with Data Transfer modifier (nearest surface). |
+| Export | PyNifly CLI `pynifly export` preset `civ4_leaderhead` | Non-shader copy created by duplicating mesh and disabling shader nodes. |
+| Texture compression | `texconv 10.1.3` | Diffuse/spec: `-f DXT5`, normal: `-f BC5_UNORM`. |
+
+## Progress Checklist
+
+- [x] Repo scaffolding created (`CoreFiles/.../Leaderheads/eleanor_roosevelt`, manifest JSON, doc stub).
+- [x] Reference photos curated and licensed.
+- [ ] FaceBuilder solve – aligned but needs manual adjustment for chin fullness.
+- [ ] Sculpt refinement – add period-accurate hairstyle and fur collar.
+- [ ] Retopology + UV unwrap.
+- [ ] Texture baking + DDS conversion.
+- [ ] Rig/skin transfer (Victoria skeleton).
+- [ ] Animation binding (reuse Victoria KF set for MVP).
+- [ ] XML snippets inserted & validated.
+- [ ] `.\tools\test_gate.ps1` run covering new XML.
+- [ ] In-game diplomacy smoke test recorded.
+
+## File Expectations
+
+`CoreFiles/.../Assets/Art/Leaderheads/eleanor_roosevelt/`
+
+- `eleanor_roosevelt.nif` / `eleanor_roosevelt_noshader.nif`
+- `eleanor_roosevelt.kfm`
+- `eleanor_roosevelt_idle_01_friendly.kf` (etc.) – start by copying Victoria clips.
+- `eleanor_roosevelt_bg.nif` / `.kfm` (temporary reuse of Victoria background)
+- Textures: `eleanor_roosevelt_diff.dds`, `eleanor_roosevelt_nrml.dds`, `eleanor_roosevelt_spec.dds`, `eleanor_roosevelt_env.dds`, `eleanor_roosevelt_env_mask.dds`.
+- Button: `Art/LeaderHeads/eleanor_roosevelt_button.dds` (64×64).
+
+Manifest path: `tools/leaderhead_pipeline/configs/eleanor_roosevelt.json`.
+
+## Validation Plan
+
+1. Run `.\tools\test_gate.ps1` after XML hook-up.
+2. Install assets into a local BTS copy, launch DowagerMod, and:
+   - Start a custom game as Eleanor, ensure portrait loads.
+   - Enter diplomacy and cycle through all deal responses.
+   - Save/load to ensure no crash.
+3. Document observations (lighting, clipping, facial animation quality) back here.
+
+## Outstanding Questions / Risks
+
+- Does reusing Victoria’s animation set create noticeable mismatch (e.g., gesture style) for Eleanor?
+- Hat brim may clip through the reused skeleton bones; may require simple bone-driven controllers or soft-body animation.
+- Need confirmation on shader choice (non-shader fallback mandatory for low-end users).

--- a/docs/plans/active/2026-03-19-leaderhead-pipeline.md
+++ b/docs/plans/active/2026-03-19-leaderhead-pipeline.md
@@ -1,0 +1,160 @@
+# Leaderhead Photo-to-BTS Pipeline
+
+- Status: `in_progress`
+- Owner / agent: Symphony Squad – Implementer
+- Last updated: `2026-03-19`
+
+## Problem Statement
+
+- Task: Build a repeatable workflow plus repo-side tooling that turns real-person photo references into fully animated Civilization IV: Beyond the Sword leaderheads compatible with DowagerMod.
+- Current observed behavior: The repo ships lots of imported leaderheads but no documented or automated path for generating new ones from scratch; adding a new real-person leaderhead is ad-hoc, manual, and not reproducible.
+- Why this is a real repo/code problem: Future leaders on the roadmap depend on custom art; without a defined pipeline, the team cannot reliably produce or review new leaderheads, and failures could break diplomacy scenes or crash the game.
+
+## Why This Matters
+
+- User or gameplay impact: Animated leaderheads are a defining UX element; missing or broken leaderheads break immersion and can block new civ content entirely.
+- Maintenance / workflow / agent impact: A codified process reduces single-artist dependency, helps agents scope art tasks, and ensures assets land with the correct XML/art wiring and validation.
+
+## Scope
+
+- In scope:
+  - Reverse-engineering the required asset stack (NIF/KFM/FGD/texture/button/XML references).
+  - Selecting and documenting a modern toolchain (e.g., Blender + Niftools + FaceBuilder/photogrammetry) that outputs compatible Gamebryo assets.
+  - Designing repo scripts/templates to organize new leaderhead deliveries and automate validation/packaging where possible.
+  - Producing at least one prototype leaderhead package sourced from a real figure photo to prove the pipeline.
+  - Updating docs/runbooks so other modders can repeat the workflow.
+- In scope:
+  - Capturing limitations, manual touchpoints, and testing requirements (XML validation + in-game smoke tests).
+
+## Non-Goals
+
+- Not changing: Core DLL leaderhead logic or diplomacy scene behavior.
+- Not changing: Existing vanilla/vended leaderhead assets beyond referencing them as exemplars.
+
+## Trusted Sources Of Truth
+
+- Primary code/config/scripts:
+  - `CoreFiles/.../Assets/XML/Art/CIV4ArtDefines_Leaderhead.xml`
+  - `CoreFiles/.../Assets/XML/Civilizations/CIV4LeaderHeadInfos.xml`
+  - `CoreFiles/.../Assets/Art/Leaderheads/**`
+  - `tools/` for packaging/testing
+- Runtime entrypoints/import paths to verify:
+  - Diplomacy scene art refs in XML
+  - Buttons/interface art hooks
+- Validation scripts/tests/hooks:
+  - `.\tools\test_gate.ps1`
+  - Manual diplomacy-scene smoke test per `docs/MANUAL_SMOKE_TESTS.md`
+
+## Existing Docs / Plans Trust Review
+
+- Reviewed docs/plans:
+  - `docs/CIV4_UNIT_ART_CRASH_PLAYBOOK.md` – trusted for art validation patterns.
+  - `docs/MANUAL_SMOKE_TESTS.md` – trusted for gameplay smoke guidance.
+  - `docs/plans/active/2026-03-09-baseline-normalization.md` – context only.
+- Conflicts with code/config/scripts: none spotted yet; rely on live XML/art paths.
+
+## Potentially Stale Or Conflicting Materials
+
+- Item: Historical forum tutorials on Civ4 leaderheads.
+  - Why it may be stale: Target old 3ds Max + obsolete plugins.
+  - What code/config overrode or verified it: Need a Blender-era workflow aligned with repo assets.
+
+## Affected Files / Directories
+
+- Primary implementation paths:
+  - `CoreFiles/.../Assets/Art/Leaderheads/**`
+  - `CoreFiles/.../Assets/XML/Art/CIV4ArtDefines_Leaderhead.xml`
+  - `docs/` (new workflow/readme)
+  - `tools/leaderhead_pipeline/**` (new scripts)
+- Adjacent paths to inspect:
+  - `CoreFiles/.../Assets/Art/interface/Leaderheads`
+  - `CoreFiles/.../Assets/Art/Shared` textures/materials
+- Paths to avoid unless evidence requires them:
+  - Base `Assets` and `Warlords` mirrors
+  - `petromod_v1` HUD tree
+
+## Assumptions That Need Human Confirmation
+
+- Assumption: Blender + Niftools (PyNifly or Civ4 FBX to NIF pipeline) is acceptable for repo contributors.
+  - Why it matters: Determines tool support we document and script.
+  - What changes if false: Need to document 3ds Max pipeline or alternative tooling.
+- Assumption: Reusing an existing Firaxis animation skeleton (e.g., Boudica) is acceptable for MVP leaderheads.
+  - Why it matters: Avoids building custom KFMs from scratch.
+  - What changes if false: Must invest in bespoke animation authoring per leader.
+
+## Proposed Implementation Steps
+
+1. Verify live entrypoints, imports, runtime paths, and active asset roots.
+2. Confirm trusted sources and classify stale/conflicting materials in this area.
+3. Implement the smallest change that solves the problem.
+4. Update related docs/runbooks affected by the change.
+5. Validate with repo test gates and required smoke testing.
+
+### Task-Specific Steps
+
+1. Inventory an existing BTS leaderhead (DowagerCountess + vanilla ref) to map required files, textures, and XML hooks.
+2. Research and document a Blender-based workflow for generating head mesh + textures from photo refs (FaceBuilder, photogrammetry, or AI-assisted sculpt) and retargeting onto Civ4 rigs.
+3. Create repo scaffolding: `tools/leaderhead_pipeline/README.md`, template folders, automation scripts for packaging assets, DDS conversion helpers, and XML stub generator.
+4. Produce a prototype leaderhead package (select a historical figure with available photos), showing the configured art tree + XML stub + build log; include instructions for manual animation binding/testing.
+5. Update docs (`docs/leaderhead_pipeline.md` + `docs/index.md` entry) and note validation/manual steps; run `.\tools\test_gate.ps1` for XML changes and document pending manual diplomacy smoke test.
+
+## Validation Plan
+
+- Required automated checks:
+  - `.\tools\test_gate.ps1`
+- Required repo scripts:
+  - To be determined (e.g., texture conversion helper tests)
+- Required manual smoke test:
+  - Install new leaderhead assets, load diplomacy scene, verify animations (document if pending).
+- Validation blocked or not yet runnable:
+  - Prototype leaderhead in-game validation pending asset completion.
+
+## Documentation Updates Required
+
+- Docs to update with the implementation:
+  - New `docs/leaderhead_pipeline.md`
+  - `docs/index.md` reference
+  - Possibly `README.md` tooling list
+- Docs/plans to mark stale, historical, or superseded:
+  - Any legacy instructions encountered (TBD)
+- `docs/index.md` updates needed:
+  - Add the new doc under Engineering / Runbooks
+- `ARCHITECTURE.md` / `WORKFLOW.md` / runbook updates needed:
+  - Likely none unless new runtime dependencies emerge.
+
+## Risks / Rollback
+
+- Main risks:
+  - Toolchain dependency (FaceBuilder license, PyNifly stability)
+  - Poor animation quality causing crashes
+- Likely failure modes:
+  - NIF export incompatible with Civ4 shaders
+  - Incorrect texture path causing pink leaderheads
+- Safe rollback approach:
+  - Remove new art/XML entries and revert doc/tool changes; existing leaderheads unaffected.
+- Paths that should not be touched during rollback:
+  - Base BtS vanilla leaderheads outside new prototype scope.
+
+## Open Questions
+
+- Question: Which historical figure should serve as the prototype (based on photo availability and licensing)?
+- Question: Do we standardize on DDS compression targets per texture map (DXT1 vs DXT5) for pipeline automation?
+
+## Completion Checklist
+
+- [ ] Trusted sources of truth were verified from code/config/scripts.
+- [ ] Existing docs/plans in this area were reviewed and classified for trustworthiness.
+- [ ] Assumptions needing human confirmation were recorded.
+- [ ] Implementation steps were completed or explicitly deferred.
+- [ ] Required validation ran and results were recorded.
+- [ ] Required manual smoke test ran, or the blocker was escalated.
+- [ ] Related docs were updated or explicitly deferred with reason.
+- [ ] Residual risks and open questions were summarized.
+
+## Final Outcome Summary
+
+- What changed:
+- Validation performed:
+- Docs updated:
+- Remaining risks:
+- Follow-up tasks:

--- a/tools/leaderhead_pipeline/README.md
+++ b/tools/leaderhead_pipeline/README.md
@@ -1,0 +1,41 @@
+# Leaderhead Pipeline Helper Scripts
+
+This folder hosts lightweight automation that supports the photo-to-leaderhead workflow described in `docs/leaderhead_pipeline.md`.
+
+## `scaffold_leaderhead.py`
+
+Creates all repo-side scaffolding for a new leaderhead:
+
+1. Art directory under `CoreFiles/.../Assets/Art/Leaderheads/<slug>/` with a drop-in checklist.
+2. Prototype build-log doc under `docs/leaderhead_pipeline/prototypes/<slug>.md`.
+3. JSON manifest under `tools/leaderhead_pipeline/configs/<slug>.json` that records file expectations (NIF, KFM, KF, textures, button, XML snippets).
+
+### Usage
+
+```
+python tools/leaderhead_pipeline/scaffold_leaderhead.py ^
+  --name "Eleanor Roosevelt" ^
+  --slug eleanor_roosevelt ^
+  --art-def ART_DEF_LEADER_ELEANOR_ROOSEVELT ^
+  --base-art-def ART_DEF_LEADER_VICTORIA
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--name` | Display name (used in docs + manifest). |
+| `--slug` | Filesystem-friendly identifier. Defaults to snake_case of name. |
+| `--art-def` | Target `ART_DEF_LEADER_*` tag. Autofills from slug if omitted. |
+| `--base-art-def` | Existing art define whose animations/rig you plan to reuse. |
+| `--force` | Overwrite existing manifest/doc/art README if you need to regenerate. |
+
+The script prints ready-to-paste XML snippets for `CIV4ArtDefines_Leaderhead.xml` and `CIV4LeaderHeadInfos.xml`, but it does **not** edit those files automatically. Keep XML edits manual until we finish end-to-end validation.
+
+## Future Helpers
+
+Reserved namespace for:
+
+- `bundle_leaderhead.py` – zip art assets and emit XML patches.
+- `verify_textures.py` – ensure DDS compression/size requirements.
+- `kf_report.py` – list animation clips referenced by a `.kfm`.

--- a/tools/leaderhead_pipeline/configs/eleanor_roosevelt.json
+++ b/tools/leaderhead_pipeline/configs/eleanor_roosevelt.json
@@ -1,0 +1,23 @@
+{
+  "name": "Eleanor Roosevelt",
+  "slug": "eleanor_roosevelt",
+  "art_def": "ART_DEF_LEADER_ELEANOR_ROOSEVELT",
+  "leader_type": "LEADER_ELEANOR_ROOSEVELT",
+  "base_art_def": "ART_DEF_LEADER_VICTORIA",
+  "created_at": "2026-03-20T04:32:05.735067+00:00",
+  "paths": {
+    "nif": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt.nif",
+    "nif_noshader": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_noshader.nif",
+    "kfm": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt.kfm",
+    "background_nif": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_bg.nif",
+    "background_kfm": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_bg.kfm",
+    "button": "art/LeaderHeads/eleanor_roosevelt_button.dds",
+    "textures": {
+      "diffuse": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_diff.dds",
+      "normal": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_nrml.dds",
+      "specular": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_spec.dds",
+      "env": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_env.dds",
+      "env_mask": "art/LeaderHeads/eleanor_roosevelt/eleanor_roosevelt_env_mask.dds"
+    }
+  }
+}

--- a/tools/leaderhead_pipeline/scaffold_leaderhead.py
+++ b/tools/leaderhead_pipeline/scaffold_leaderhead.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Scaffold directories, docs, and manifests for a new Civ4 BTS leaderhead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import sys
+from textwrap import dedent
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ASSETS_ROOT = (
+    REPO_ROOT
+    / "CoreFiles"
+    / "Sid Meier's Civilization IV Beyond the Sword"
+    / "Beyond the Sword"
+    / "Assets"
+)
+LEADERHEAD_ART_ROOT = ASSETS_ROOT / "Art" / "Leaderheads"
+DOCS_PROTO_ROOT = REPO_ROOT / "docs" / "leaderhead_pipeline" / "prototypes"
+CONFIG_ROOT = Path(__file__).resolve().parent / "configs"
+
+
+def slugify(name: str) -> str:
+    slug = re.sub(r"[^0-9a-zA-Z]+", "_", name.strip()).strip("_").lower()
+    return slug or "leaderhead"
+
+
+def derive_art_def(slug: str) -> str:
+    return f"ART_DEF_LEADER_{slug.upper()}"
+
+
+def derive_leader_type(slug: str) -> str:
+    return f"LEADER_{slug.upper()}"
+
+
+def write_text(path: Path, content: str, force: bool) -> bool:
+    if path.exists() and not force:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def build_manifest(
+    name: str,
+    slug: str,
+    art_def: str,
+    leader_type: str,
+    base_art_def: str,
+) -> dict:
+    art_rel = f"art/LeaderHeads/{slug}"
+    button_rel = f"art/LeaderHeads/{slug}_button.dds"
+    manifest = {
+        "name": name,
+        "slug": slug,
+        "art_def": art_def,
+        "leader_type": leader_type,
+        "base_art_def": base_art_def,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "paths": {
+            "nif": f"{art_rel}/{slug}.nif",
+            "nif_noshader": f"{art_rel}/{slug}_noshader.nif",
+            "kfm": f"{art_rel}/{slug}.kfm",
+            "background_nif": f"{art_rel}/{slug}_bg.nif",
+            "background_kfm": f"{art_rel}/{slug}_bg.kfm",
+            "button": button_rel,
+            "textures": {
+                "diffuse": f"{art_rel}/{slug}_diff.dds",
+                "normal": f"{art_rel}/{slug}_nrml.dds",
+                "specular": f"{art_rel}/{slug}_spec.dds",
+                "env": f"{art_rel}/{slug}_env.dds",
+                "env_mask": f"{art_rel}/{slug}_env_mask.dds",
+            },
+        },
+    }
+    return manifest
+
+
+def art_readme_content(name: str, slug: str) -> str:
+    return dedent(
+        f"""\
+        # {name} Leaderhead Drop Folder
+
+        Place exported assets here once Blender/PyNifly export completes.
+
+        Required files:
+        - {{slug}}.nif / {{slug}}_noshader.nif (shader + fallback)
+        - {{slug}}.kfm (animation controller)
+        - Animation clips (KF) referenced by the KFM
+        - Background: {{slug}}_bg.nif / {{slug}}_bg.kfm / {{slug}}_bg_background.kf
+        - Textures: {{slug}}_diff.dds, {{slug}}_nrml.dds, {{slug}}_spec.dds, {{slug}}_env.dds, {{slug}}_env_mask.dds
+        - Button art: ../Interface/LeaderHeads/{{slug}}_button.dds
+
+        Run `python tools/leaderhead_pipeline/scaffold_leaderhead.py --help` for details.
+        """
+    ).replace("{slug}", slug)
+
+
+def prototype_doc_template(name: str, slug: str, art_def: str, base_art_def: str) -> str:
+    return dedent(
+        f"""\
+        # {name} Leaderhead Prototype (WIP)
+
+        - **Slug:** `{slug}`
+        - **ArtDefine:** `{art_def}`
+        - **Base rig / animation set:** `{base_art_def}`
+        - **Last scaffolded:** {datetime.now(timezone.utc).date().isoformat()}
+
+        ## TODO
+
+        - [ ] Collect/record photo references + licensing
+        - [ ] Face reconstruction & sculpt
+        - [ ] Retopology + UVs
+        - [ ] Texture bake + DDS export
+        - [ ] Rig transfer + animation binding
+        - [ ] Background + button art
+        - [ ] XML snippets inserted
+        - [ ] `tools/test_gate.ps1`
+        - [ ] In-game diplomacy smoke test
+
+        Update this doc as you make progress (see `docs/leaderhead_pipeline.md` for the expected content).
+        """
+    )
+
+
+def xml_snippets(name: str, slug: str, art_def: str, leader_type: str) -> tuple[str, str]:
+    art = dedent(
+        f"""\
+        <!-- {name} -->
+        <LeaderheadArtInfo>
+            <Type>{art_def}</Type>
+            <Button>art/LeaderHeads/{slug}_button.dds</Button>
+            <NIF>art/LeaderHeads/{slug}/{slug}.nif</NIF>
+            <KFM>art/LeaderHeads/{slug}/{slug}.kfm</KFM>
+            <NoShaderNIF>art/LeaderHeads/{slug}/{slug}_noshader.nif</NoShaderNIF>
+            <BackgroundKFM>art/LeaderHeads/{slug}/{slug}_bg.kfm</BackgroundKFM>
+        </LeaderheadArtInfo>"""
+    )
+    info = dedent(
+        f"""\
+        <!-- {name} -->
+        <LeaderHeadInfo>
+            <Type>{leader_type}</Type>
+            <Description>{name}</Description>
+            <Civilopedia>{name}</Civilopedia>
+            <ArtDefineTag>{art_def}</ArtDefineTag>
+            <!-- TODO: fill in personality stats before committing -->
+        </LeaderHeadInfo>"""
+    )
+    return art, info
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True, help="Display name for the leader.")
+    parser.add_argument("--slug", help="Filesystem/name slug (snake_case).")
+    parser.add_argument("--art-def", help="Art define tag (ART_DEF_LEADER_*).")
+    parser.add_argument(
+        "--base-art-def",
+        default="ART_DEF_LEADER_VICTORIA",
+        help="Existing art define whose rig/animations you plan to reuse.",
+    )
+    parser.add_argument("--force", action="store_true", help="Overwrite existing files.")
+    args = parser.parse_args(argv)
+
+    slug = args.slug or slugify(args.name)
+    art_def = args.art_def or derive_art_def(slug)
+    leader_type = derive_leader_type(slug)
+
+    # 1. Art directory + README
+    art_dir = LEADERHEAD_ART_ROOT / slug
+    art_dir.mkdir(parents=True, exist_ok=True)
+    art_readme_path = art_dir / "README.txt"
+    art_readme_written = write_text(
+        art_readme_path, art_readme_content(args.name, slug), args.force
+    )
+
+    # 2. Prototype doc template
+    DOCS_PROTO_ROOT.mkdir(parents=True, exist_ok=True)
+    proto_doc_path = DOCS_PROTO_ROOT / f"{slug}.md"
+    prototype_written = write_text(
+        proto_doc_path,
+        prototype_doc_template(args.name, slug, art_def, args.base_art_def),
+        args.force,
+    )
+
+    # 3. Manifest JSON
+    CONFIG_ROOT.mkdir(parents=True, exist_ok=True)
+    manifest_path = CONFIG_ROOT / f"{slug}.json"
+    manifest = build_manifest(args.name, slug, art_def, leader_type, args.base_art_def)
+    manifest_written = write_text(
+        manifest_path, json.dumps(manifest, indent=2) + "\n", args.force
+    )
+
+    art_xml, info_xml = xml_snippets(args.name, slug, art_def, leader_type)
+
+    print(f"[+] Art directory: {art_dir}")
+    if art_readme_written:
+        print(f"    • Wrote {art_readme_path.name}")
+    else:
+        print(f"    • Kept existing {art_readme_path.name}")
+
+    print(f"[+] Prototype doc: {proto_doc_path}")
+    print(
+        "    • "
+        + (
+            "Created template"
+            if prototype_written
+            else "Already existed (not overwritten)"
+        )
+    )
+
+    print(f"[+] Manifest: {manifest_path}")
+    print(
+        "    • "
+        + ("Wrote manifest" if manifest_written else "Already existed (not overwritten)")
+    )
+
+    print("\n=== CIV4ArtDefines_Leaderhead snippet ===")
+    print(art_xml)
+    print("\n=== CIV4LeaderHeadInfos snippet ===")
+    print(info_xml)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Automated Symphony handoff for #56.

## Summary
- Issue: #56
- Branch: `symphony/56-tool-for-making-civ-leaderheads`

## Changed Files
- `CoreFiles/Sid Meier's Civilization IV Beyond the Sword/Beyond the Sword/Assets/Art/Leaderheads/eleanor_roosevelt/README.txt`
- `docs/index.md`
- `docs/leaderhead_pipeline.md`
- `docs/leaderhead_pipeline/prototypes/eleanor_roosevelt.md`
- `docs/plans/active/2026-03-19-leaderhead-pipeline.md`
- `tools/leaderhead_pipeline/README.md`
- `tools/leaderhead_pipeline/configs/eleanor_roosevelt.json`
- `tools/leaderhead_pipeline/scaffold_leaderhead.py`

## Plan Docs
- `docs/plans/active/2026-03-19-leaderhead-pipeline.md`

## Validation
No repo-native validation gate was required.

Closes #56